### PR TITLE
ci: standardize workflow with micromamba, fix rasterio PROJ conflict, verify ee-api fork

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,11 @@ jobs:
           environment-file: sepal_environment.yml
           cache-environment: true
 
+      - name: Verify ee-api fork
+        shell: micromamba-shell {0}
+        run: |
+          python -c "import ee; v=ee.__version__; print('ee-api:', v); assert v == '1.1.5rc0', 'Expected fork 1.1.5rc0, got ' + v"
+
       - name: Install test deps
         shell: micromamba-shell {0}
         run: pip install pytest nbmake ipykernel


### PR DESCRIPTION
## Summary

- Replaces legacy \`unit.yaml\` with standardized \`ci.yaml\` using \`mamba-org/setup-micromamba\`
- Moves \`rasterio\` and \`sepal-ui\` from pip to conda to fix PROJ/proj.db version mismatch (\`CRSError: DATABASE.LAYOUT.VERSION.MINOR = 2 whereas >= 3 expected\`)
- Adds a **Verify ee-api fork** step that asserts the openforis fork is installed instead of the conda-forge version

## Root cause of PROJ error
pip-installed \`rasterio\` bundles its own newer \`libproj\` which expects \`proj.db\` v3+, but conda's \`proj\` package ships v2. Fix: install both \`rasterio\` and \`sepal-ui\` via conda so all geospatial native libs are version-consistent.